### PR TITLE
fix(docs): `README.rst` build error in 0.10.0 Doc

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -26,7 +26,7 @@ jobs:
           default: true
       - name: Install Python packages
         run: |
-          pip install maturin sphinx myst-parser[sphinx]
+          pip install maturin sphinx
       - name: Build ulist
         run: |
           maturin build --out dist -m ulist/Cargo.toml

--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,7 @@ Performance
 
 | Ulist is extremly fast, and even compared with libraries like Numpy.
   It is
+
 - more efficient on the ``string`` and ``boolean`` array,
 - same level efficient on the ``integer`` array,
 - and a bit slower on the ``floating`` array.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,7 +33,6 @@ release = '0.10.0'
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.githubpages',
-    'myst_parser',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -59,3 +58,5 @@ html_static_path = []
 
 
 master_doc = 'index'
+
+source_suffix = { '.rst': 'restructuredtext' }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,5 +7,4 @@ Welcome to ulist's documentation!
 
 
 
-.. include:: ../README.md
-   :parser: myst_parser.sphinx_
+.. include:: ../README.rst


### PR DESCRIPTION
Changes below:

1. `markdown` format is no longer needed, so I remove the package `myst-parser[sphinx]`
2. Modify `../README.md` to `../README.rst` in `docs/index.rst` so that `sphinx` could find it
3. Add a blank line in `README.rst` to avoid warning

I have tested locally and all works fine.