### PR TITLE
fix(base): fix `index out of range` when using iterator

### DIFF
--- a/ulist/src/base.rs
+++ b/ulist/src/base.rs
@@ -1,5 +1,7 @@
 use crate::boolean::BooleanList;
 use crate::index::IndexList;
+use pyo3::exceptions::PyIndexError;
+use pyo3::PyResult;
 use std::cell::Ref;
 use std::cell::RefMut;
 use std::collections::HashSet;
@@ -121,16 +123,16 @@ where
         List::_new(vec, hset)
     }
 
-    fn get(&self, index: usize) -> Option<T> {
+    fn get(&self, index: usize) -> PyResult<Option<T>> {
         if self.na_indexes().contains(&index) {
-            return None;
+            return Ok(None);
         }
         let vec = self.values();
         let val = vec.get(index);
         if let Some(i) = val {
-            return Some(i.clone());
+            Ok(Some(i.clone()))
         } else {
-            panic!("Index out of range!");
+            Err(PyIndexError::new_err("Index out of range!"))
         }
     }
 

--- a/ulist/src/boolean.rs
+++ b/ulist/src/boolean.rs
@@ -97,7 +97,7 @@ impl BooleanList {
         List::filter(self, condition)
     }
 
-    pub fn get(&self, index: usize) -> Option<bool> {
+    pub fn get(&self, index: usize) -> PyResult<Option<bool>> {
         List::get(self, index)
     }
 

--- a/ulist/src/control_flow.rs
+++ b/ulist/src/control_flow.rs
@@ -27,7 +27,7 @@ where
     for j in 0..cond[0].size() {
         for i in 0..cond.len() {
             // TODO: Improve the benchmark.
-            if cond[i].get(j).unwrap() {
+            if cond[i].get(j).unwrap().unwrap() {
                 vec[j] = choices[i].clone();
                 break;
             }

--- a/ulist/src/floatings/float32.rs
+++ b/ulist/src/floatings/float32.rs
@@ -104,7 +104,7 @@ impl FloatList32 {
         List::filter(self, condition)
     }
 
-    pub fn get(&self, index: usize) -> Option<f32> {
+    pub fn get(&self, index: usize) -> PyResult<Option<f32>> {
         List::get(self, index)
     }
 

--- a/ulist/src/floatings/float64.rs
+++ b/ulist/src/floatings/float64.rs
@@ -104,7 +104,7 @@ impl FloatList64 {
         List::filter(self, condition)
     }
 
-    pub fn get(&self, index: usize) -> Option<f64> {
+    pub fn get(&self, index: usize) -> PyResult<Option<f64>> {
         List::get(self, index)
     }
 

--- a/ulist/src/integers/int32.rs
+++ b/ulist/src/integers/int32.rs
@@ -115,7 +115,7 @@ impl IntegerList32 {
         List::filter(self, condition)
     }
 
-    pub fn get(&self, index: usize) -> Option<i32> {
+    pub fn get(&self, index: usize) -> PyResult<Option<i32>> {
         List::get(self, index)
     }
 

--- a/ulist/src/integers/int64.rs
+++ b/ulist/src/integers/int64.rs
@@ -117,7 +117,7 @@ impl IntegerList64 {
         List::filter(self, condition)
     }
 
-    pub fn get(&self, index: usize) -> Option<i64> {
+    pub fn get(&self, index: usize) -> PyResult<Option<i64>> {
         List::get(self, index)
     }
 

--- a/ulist/src/string.rs
+++ b/ulist/src/string.rs
@@ -96,7 +96,7 @@ impl StringList {
         List::filter(self, condition)
     }
 
-    pub fn get(&self, index: usize) -> Option<String> {
+    pub fn get(&self, index: usize) -> PyResult<Option<String>> {
         List::get(self, index)
     }
 


### PR DESCRIPTION
I found a bug:
```python
>>> import ulist as ul
>>> foo = ul.arange(2)
>>> iterater = iter(foo)
>>> next(iterater)
0
>>> next(iterater)
1
>>> next(iterater)
thread '<unnamed>' panicked at 'Index '2' out of range '2'!', src/base.rs:133:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/yingmanwumen/Documents/Codes/Rust/ulist/ulist/python/ulist/core.py", line 80, in __getitem__
    return self._values.get(index)
pyo3_runtime.PanicException: Index '2' out of range '2'!
```



This causes the following code to fail
```python
...
foo = ul.arange(n)
for x in foo:
    # ....do something
...
```

I found that the use of `panic` instead of `exception` in the rust code result in it.


