### PR TITLE
refactor: using pyerr instead of panic

### DIFF
--- a/ulist/src/boolean.rs
+++ b/ulist/src/boolean.rs
@@ -44,7 +44,7 @@ impl BooleanList {
         List::all_equal(self, other)
     }
 
-    pub fn and_(&self, other: &Self) -> Self {
+    pub fn and_(&self, other: &Self) -> PyResult<Self> {
         _logical_operate(&self, &other, |x, y| x && y)
     }
 
@@ -97,7 +97,7 @@ impl BooleanList {
         List::equal_scala(self, elem)
     }
 
-    pub fn filter(&self, condition: &BooleanList) -> Self {
+    pub fn filter(&self, condition: &BooleanList) -> PyResult<Self> {
         List::filter(self, condition)
     }
 
@@ -105,7 +105,7 @@ impl BooleanList {
         List::get(self, index)
     }
 
-    pub fn get_by_indexes(&self, indexes: &IndexList) -> Self {
+    pub fn get_by_indexes(&self, indexes: &IndexList) -> PyResult<Self> {
         List::get_by_indexes(self, indexes)
     }
 
@@ -120,7 +120,7 @@ impl BooleanList {
         List::not_equal_scala(self, elem)
     }
 
-    pub fn or_(&self, other: &Self) -> Self {
+    pub fn or_(&self, other: &Self) -> PyResult<Self> {
         _logical_operate(&self, &other, |x, y| x || y)
     }
 
@@ -137,7 +137,7 @@ impl BooleanList {
         List::replace(self, old, new)
     }
 
-    pub fn set(&self, index: usize, elem: Option<bool>) {
+    pub fn set(&self, index: usize, elem: Option<bool>) -> PyResult<()> {
         List::set(self, index, elem)
     }
 
@@ -212,15 +212,15 @@ fn _logical_operate(
     this: &BooleanList,
     other: &BooleanList,
     func: impl Fn(bool, bool) -> bool,
-) -> BooleanList {
-    this._check_len_eq(other);
+) -> PyResult<BooleanList> {
+    this._check_len_eq(other)?;
     let vec = this
         .values()
         .iter()
         .zip(other.values().iter())
         .map(|(&x, &y)| func(x, y))
         .collect();
-    BooleanList::new(vec, HashSet::new())
+    Ok(BooleanList::new(vec, HashSet::new()))
 }
 
 impl AsFloatList32 for BooleanList {

--- a/ulist/src/control_flow.rs
+++ b/ulist/src/control_flow.rs
@@ -3,11 +3,18 @@ use crate::boolean::BooleanList;
 use crate::floatings::FloatList64;
 use crate::integers::IntegerList64;
 use crate::string::StringList;
+use pyo3::exceptions::PyRuntimeError;
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::Py;
 use std::collections::HashSet;
 
-fn select<T, U>(py: Python, conditions: &Vec<Py<BooleanList>>, choices: &Vec<T>, default: T) -> U
+fn select<T, U>(
+    py: Python,
+    conditions: &Vec<Py<BooleanList>>,
+    choices: &Vec<T>,
+    default: T,
+) -> PyResult<U>
 where
     T: PartialEq + Clone,
     U: List<T>,
@@ -16,10 +23,13 @@ where
     let n = cond[0].size();
     for c in cond.iter() {
         if c.size() != n {
-            panic!("BooleanList sizes in conditions should be equal!");
-        }
-        if c.count_na() > 0 {
-            panic!("Parameter `condition` should not contain missing values!");
+            return Err(PyRuntimeError::new_err(
+                "BooleanList sizes in conditions should be equal!",
+            ));
+        } else if c.count_na() > 0 {
+            return Err(PyValueError::new_err(
+                "Parameter `condition` should not contain missing values!",
+            ));
         }
     }
 
@@ -33,7 +43,7 @@ where
             }
         }
     }
-    U::_new(vec, HashSet::new())
+    Ok(U::_new(vec, HashSet::new()))
 }
 
 #[pyfunction]
@@ -42,7 +52,7 @@ pub fn select_bool(
     conditions: Vec<Py<BooleanList>>,
     choices: Vec<bool>,
     default: bool,
-) -> BooleanList {
+) -> PyResult<BooleanList> {
     select::<bool, BooleanList>(py, &conditions, &choices, default)
 }
 
@@ -52,7 +62,7 @@ pub fn select_float(
     conditions: Vec<Py<BooleanList>>,
     choices: Vec<f64>,
     default: f64,
-) -> FloatList64 {
+) -> PyResult<FloatList64> {
     select::<f64, FloatList64>(py, &conditions, &choices, default)
 }
 
@@ -62,7 +72,7 @@ pub fn select_int(
     conditions: Vec<Py<BooleanList>>,
     choices: Vec<i64>,
     default: i64,
-) -> IntegerList64 {
+) -> PyResult<IntegerList64> {
     select::<i64, IntegerList64>(py, &conditions, &choices, default)
 }
 
@@ -72,6 +82,6 @@ pub fn select_string(
     conditions: Vec<Py<BooleanList>>,
     choices: Vec<String>,
     default: String,
-) -> StringList {
+) -> PyResult<StringList> {
     select::<String, StringList>(py, &conditions, &choices, default)
 }

--- a/ulist/src/floatings/float32.rs
+++ b/ulist/src/floatings/float32.rs
@@ -33,7 +33,7 @@ impl FloatList32 {
         List::_new(vec, hset)
     }
 
-    pub fn add(&self, other: &Self) -> Self {
+    pub fn add(&self, other: &Self) -> PyResult<Self> {
         NumericalList::add(self, other)
     }
 
@@ -49,11 +49,11 @@ impl FloatList32 {
         List::append(self, elem)
     }
 
-    pub fn argmax(&self) -> usize {
+    pub fn argmax(&self) -> PyResult<usize> {
         NumericalList::argmax(self)
     }
 
-    pub fn argmin(&self) -> usize {
+    pub fn argmin(&self) -> PyResult<usize> {
         NumericalList::argmin(self)
     }
 
@@ -90,9 +90,9 @@ impl FloatList32 {
         List::cycle(&vec, size)
     }
 
-    pub fn div(&self, other: &Self) -> Self {
+    pub fn div(&self, other: &Self) -> PyResult<Self> {
         let hset = self.na_indexes().clone();
-        FloatList32::new(NumericalList::div(self, other), hset)
+        Ok(FloatList32::new(NumericalList::div(self, other)?, hset))
     }
 
     pub fn div_scala(&self, elem: f32) -> Self {
@@ -104,7 +104,7 @@ impl FloatList32 {
         List::equal_scala(self, elem)
     }
 
-    pub fn filter(&self, condition: &BooleanList) -> Self {
+    pub fn filter(&self, condition: &BooleanList) -> PyResult<Self> {
         List::filter(self, condition)
     }
 
@@ -112,7 +112,7 @@ impl FloatList32 {
         List::get(self, index)
     }
 
-    pub fn get_by_indexes(&self, indexes: &IndexList) -> Self {
+    pub fn get_by_indexes(&self, indexes: &IndexList) -> PyResult<Self> {
         List::get_by_indexes(self, indexes)
     }
 
@@ -132,15 +132,15 @@ impl FloatList32 {
         NumericalList::less_than_scala(self, elem)
     }
 
-    pub fn max(&self) -> f32 {
+    pub fn max(&self) -> PyResult<f32> {
         NumericalList::max(self)
     }
 
-    pub fn min(&self) -> f32 {
+    pub fn min(&self) -> PyResult<f32> {
         NumericalList::min(self)
     }
 
-    pub fn mul(&self, other: &Self) -> Self {
+    pub fn mul(&self, other: &Self) -> PyResult<Self> {
         NumericalList::mul(self, other)
     }
 
@@ -169,7 +169,7 @@ impl FloatList32 {
         List::replace(self, old, new)
     }
 
-    pub fn set(&self, index: usize, elem: Option<f32>) {
+    pub fn set(&self, index: usize, elem: Option<f32>) -> PyResult<()> {
         List::set(self, index, elem)
     }
 
@@ -192,7 +192,7 @@ impl FloatList32 {
         }
     }
 
-    pub fn sub(&self, other: &Self) -> Self {
+    pub fn sub(&self, other: &Self) -> PyResult<Self> {
         NumericalList::sub(self, other)
     }
 
@@ -267,8 +267,8 @@ impl List<f32> for FloatList32 {
 }
 
 impl NumericalList<f32, i32, f32> for FloatList32 {
-    fn argmax(&self) -> usize {
-        self._check_all_na();
+    fn argmax(&self) -> PyResult<usize> {
+        self._check_all_na()?;
         let vec = self.values();
         let hset = self.na_indexes();
         let val_0 = &f32::NEG_INFINITY;
@@ -277,11 +277,11 @@ impl NumericalList<f32, i32, f32> for FloatList32 {
             .enumerate()
             .filter(|(i, _)| !hset.contains(i))
             .fold((0, val_0), |acc, x| if x.1 > acc.1 { x } else { acc });
-        result.0
+        Ok(result.0)
     }
 
-    fn argmin(&self) -> usize {
-        self._check_all_na();
+    fn argmin(&self) -> PyResult<usize> {
+        self._check_all_na()?;
         let vec = self.values();
         let hset = self.na_indexes();
         let val_0 = &f32::INFINITY;
@@ -290,46 +290,47 @@ impl NumericalList<f32, i32, f32> for FloatList32 {
             .enumerate()
             .filter(|(i, _)| !hset.contains(i))
             .fold((0, val_0), |acc, x| if x.1 < acc.1 { x } else { acc });
-        result.0
+        Ok(result.0)
     }
 
-    fn div(&self, other: &Self) -> Vec<f32> {
-        self._check_len_eq(other);
-        self.values()
+    fn div(&self, other: &Self) -> PyResult<Vec<f32>> {
+        self._check_len_eq(other)?;
+        Ok(self
+            .values()
             .iter()
             .zip(other.values().iter())
             .map(|(x, y)| x / y)
-            .collect()
+            .collect())
     }
 
     fn div_scala(&self, elem: f32) -> Vec<f32> {
         self.values().iter().map(|x| *x / elem).collect()
     }
 
-    fn max(&self) -> f32 {
-        self._check_all_na();
+    fn max(&self) -> PyResult<f32> {
+        self._check_all_na()?;
         let hset = self.na_indexes();
-        *self
+        Ok(*self
             .values()
             .iter()
             .enumerate()
             .filter(|(i, _)| !hset.contains(i))
             .map(|(_, x)| x)
             .max_by(|&x, &y| x.partial_cmp(y).unwrap())
-            .unwrap()
+            .unwrap())
     }
 
-    fn min(&self) -> f32 {
-        self._check_all_na();
+    fn min(&self) -> PyResult<f32> {
+        self._check_all_na()?;
         let hset = self.na_indexes();
-        *self
+        Ok(*self
             .values()
             .iter()
             .enumerate()
             .filter(|(i, _)| !hset.contains(i))
             .map(|(_, x)| x)
             .min_by(|&x, &y| x.partial_cmp(y).unwrap())
-            .unwrap()
+            .unwrap())
     }
 
     fn pow_scala(&self, elem: i32) -> Self {

--- a/ulist/src/floatings/float64.rs
+++ b/ulist/src/floatings/float64.rs
@@ -33,7 +33,7 @@ impl FloatList64 {
         List::_new(vec, hset)
     }
 
-    pub fn add(&self, other: &Self) -> Self {
+    pub fn add(&self, other: &Self) -> PyResult<Self> {
         NumericalList::add(self, other)
     }
 
@@ -49,11 +49,11 @@ impl FloatList64 {
         List::append(self, elem)
     }
 
-    pub fn argmax(&self) -> usize {
+    pub fn argmax(&self) -> PyResult<usize> {
         NumericalList::argmax(self)
     }
 
-    pub fn argmin(&self) -> usize {
+    pub fn argmin(&self) -> PyResult<usize> {
         NumericalList::argmin(self)
     }
 
@@ -90,9 +90,9 @@ impl FloatList64 {
         List::cycle(&vec, size)
     }
 
-    pub fn div(&self, other: &Self) -> Self {
+    pub fn div(&self, other: &Self) -> PyResult<Self> {
         let hset = self.na_indexes().clone();
-        FloatList64::new(NumericalList::div(self, other), hset)
+        Ok(FloatList64::new(NumericalList::div(self, other)?, hset))
     }
 
     pub fn div_scala(&self, elem: f64) -> Self {
@@ -104,7 +104,7 @@ impl FloatList64 {
         List::equal_scala(self, elem)
     }
 
-    pub fn filter(&self, condition: &BooleanList) -> Self {
+    pub fn filter(&self, condition: &BooleanList) -> PyResult<Self> {
         List::filter(self, condition)
     }
 
@@ -112,7 +112,7 @@ impl FloatList64 {
         List::get(self, index)
     }
 
-    pub fn get_by_indexes(&self, indexes: &IndexList) -> Self {
+    pub fn get_by_indexes(&self, indexes: &IndexList) -> PyResult<Self> {
         List::get_by_indexes(self, indexes)
     }
 
@@ -132,15 +132,15 @@ impl FloatList64 {
         NumericalList::less_than_scala(self, elem)
     }
 
-    pub fn max(&self) -> f64 {
+    pub fn max(&self) -> PyResult<f64> {
         NumericalList::max(self)
     }
 
-    pub fn min(&self) -> f64 {
+    pub fn min(&self) -> PyResult<f64> {
         NumericalList::min(self)
     }
 
-    pub fn mul(&self, other: &Self) -> Self {
+    pub fn mul(&self, other: &Self) -> PyResult<Self> {
         NumericalList::mul(self, other)
     }
 
@@ -169,7 +169,7 @@ impl FloatList64 {
         List::replace(self, old, new)
     }
 
-    pub fn set(&self, index: usize, elem: Option<f64>) {
+    pub fn set(&self, index: usize, elem: Option<f64>) -> PyResult<()> {
         List::set(self, index, elem)
     }
 
@@ -192,7 +192,7 @@ impl FloatList64 {
         }
     }
 
-    pub fn sub(&self, other: &Self) -> Self {
+    pub fn sub(&self, other: &Self) -> PyResult<Self> {
         NumericalList::sub(self, other)
     }
 
@@ -267,8 +267,8 @@ impl List<f64> for FloatList64 {
 }
 
 impl NumericalList<f64, i32, f64> for FloatList64 {
-    fn argmax(&self) -> usize {
-        self._check_all_na();
+    fn argmax(&self) -> PyResult<usize> {
+        self._check_all_na()?;
         let vec = self.values();
         let hset = self.na_indexes();
         let val_0 = &f64::NEG_INFINITY;
@@ -277,11 +277,11 @@ impl NumericalList<f64, i32, f64> for FloatList64 {
             .enumerate()
             .filter(|(i, _)| !hset.contains(i))
             .fold((0, val_0), |acc, x| if x.1 > acc.1 { x } else { acc });
-        result.0
+        Ok(result.0)
     }
 
-    fn argmin(&self) -> usize {
-        self._check_all_na();
+    fn argmin(&self) -> PyResult<usize> {
+        self._check_all_na()?;
         let vec = self.values();
         let hset = self.na_indexes();
         let val_0 = &f64::INFINITY;
@@ -290,46 +290,47 @@ impl NumericalList<f64, i32, f64> for FloatList64 {
             .enumerate()
             .filter(|(i, _)| !hset.contains(i))
             .fold((0, val_0), |acc, x| if x.1 < acc.1 { x } else { acc });
-        result.0
+        Ok(result.0)
     }
 
-    fn div(&self, other: &Self) -> Vec<f64> {
-        self._check_len_eq(other);
-        self.values()
+    fn div(&self, other: &Self) -> PyResult<Vec<f64>> {
+        self._check_len_eq(other)?;
+        Ok(self
+            .values()
             .iter()
             .zip(other.values().iter())
             .map(|(x, y)| x / y)
-            .collect()
+            .collect())
     }
 
     fn div_scala(&self, elem: f64) -> Vec<f64> {
         self.values().iter().map(|x| *x / elem).collect()
     }
 
-    fn max(&self) -> f64 {
-        self._check_all_na();
+    fn max(&self) -> PyResult<f64> {
+        self._check_all_na()?;
         let hset = self.na_indexes();
-        *self
+        Ok(*self
             .values()
             .iter()
             .enumerate()
             .filter(|(i, _)| !hset.contains(i))
             .map(|(_, x)| x)
             .max_by(|&x, &y| x.partial_cmp(y).unwrap())
-            .unwrap()
+            .unwrap())
     }
 
-    fn min(&self) -> f64 {
-        self._check_all_na();
+    fn min(&self) -> PyResult<f64> {
+        self._check_all_na()?;
         let hset = self.na_indexes();
-        *self
+        Ok(*self
             .values()
             .iter()
             .enumerate()
             .filter(|(i, _)| !hset.contains(i))
             .map(|(_, x)| x)
             .min_by(|&x, &y| x.partial_cmp(y).unwrap())
-            .unwrap()
+            .unwrap())
     }
 
     fn pow_scala(&self, elem: i32) -> Self {

--- a/ulist/src/integers/int32.rs
+++ b/ulist/src/integers/int32.rs
@@ -35,7 +35,7 @@ impl IntegerList32 {
         List::_new(vec, hset)
     }
 
-    pub fn add(&self, other: &Self) -> Self {
+    pub fn add(&self, other: &Self) -> PyResult<Self> {
         NumericalList::add(self, other)
     }
 
@@ -51,11 +51,11 @@ impl IntegerList32 {
         List::append(self, elem)
     }
 
-    pub fn argmax(&self) -> usize {
+    pub fn argmax(&self) -> PyResult<usize> {
         NumericalList::argmax(self)
     }
 
-    pub fn argmin(&self) -> usize {
+    pub fn argmin(&self) -> PyResult<usize> {
         NumericalList::argmin(self)
     }
 
@@ -96,14 +96,14 @@ impl IntegerList32 {
         List::cycle(&vec, size)
     }
 
-    pub fn div(&self, other: &Self) -> FloatList64 {
+    pub fn div(&self, other: &Self) -> PyResult<FloatList64> {
         let hset: HashSet<usize> = self
             .na_indexes()
             .iter()
             .chain(other.na_indexes().iter())
             .map(|x| x.clone())
             .collect();
-        FloatList64::new(NumericalList::div(self, other), hset)
+        Ok(FloatList64::new(NumericalList::div(self, other)?, hset))
     }
 
     pub fn div_scala(&self, elem: f64) -> FloatList64 {
@@ -115,7 +115,7 @@ impl IntegerList32 {
         List::equal_scala(self, elem)
     }
 
-    pub fn filter(&self, condition: &BooleanList) -> Self {
+    pub fn filter(&self, condition: &BooleanList) -> PyResult<Self> {
         List::filter(self, condition)
     }
 
@@ -123,7 +123,7 @@ impl IntegerList32 {
         List::get(self, index)
     }
 
-    pub fn get_by_indexes(&self, indexes: &IndexList) -> Self {
+    pub fn get_by_indexes(&self, indexes: &IndexList) -> PyResult<Self> {
         List::get_by_indexes(self, indexes)
     }
 
@@ -143,15 +143,15 @@ impl IntegerList32 {
         NumericalList::less_than_scala(self, elem)
     }
 
-    pub fn max(&self) -> i32 {
+    pub fn max(&self) -> PyResult<i32> {
         NumericalList::max(self)
     }
 
-    pub fn min(&self) -> i32 {
+    pub fn min(&self) -> PyResult<i32> {
         NumericalList::min(self)
     }
 
-    pub fn mul(&self, other: &Self) -> Self {
+    pub fn mul(&self, other: &Self) -> PyResult<Self> {
         NumericalList::mul(self, other)
     }
 
@@ -180,7 +180,7 @@ impl IntegerList32 {
         List::replace(self, old, new)
     }
 
-    pub fn set(&self, index: usize, elem: Option<i32>) {
+    pub fn set(&self, index: usize, elem: Option<i32>) -> PyResult<()> {
         List::set(self, index, elem)
     }
 
@@ -192,7 +192,7 @@ impl IntegerList32 {
         NonFloatList::sort(self, ascending)
     }
 
-    pub fn sub(&self, other: &Self) -> Self {
+    pub fn sub(&self, other: &Self) -> PyResult<Self> {
         NumericalList::sub(self, other)
     }
 
@@ -249,35 +249,38 @@ impl List<i32> for IntegerList32 {
 impl NonFloatList<i32> for IntegerList32 {}
 
 impl NumericalList<i32, u32, f64> for IntegerList32 {
-    fn argmax(&self) -> usize {
-        self._check_all_na();
+    fn argmax(&self) -> PyResult<usize> {
+        self._check_all_na()?;
         let hset = self.na_indexes();
-        self.values()
+        Ok(self
+            .values()
             .iter()
             .enumerate()
             .filter(|(i, _)| !hset.contains(i))
             .max_by_key(|x| x.1)
             .unwrap()
-            .0
+            .0)
     }
 
-    fn argmin(&self) -> usize {
-        self._check_all_na();
+    fn argmin(&self) -> PyResult<usize> {
+        self._check_all_na()?;
         let hset = self.na_indexes();
-        self.values()
+        Ok(self
+            .values()
             .iter()
             .enumerate()
             .filter(|(i, _)| !hset.contains(i))
             .min_by_key(|x| x.1)
             .unwrap()
-            .0
+            .0)
     }
 
-    fn div(&self, other: &Self) -> Vec<f64> {
-        self._check_len_eq(other);
+    fn div(&self, other: &Self) -> PyResult<Vec<f64>> {
+        self._check_len_eq(other)?;
         let hset1 = self.na_indexes();
         let hset2 = other.na_indexes();
-        self.values()
+        Ok(self
+            .values()
             .iter()
             .enumerate()
             .zip(other.values().iter())
@@ -288,37 +291,37 @@ impl NumericalList<i32, u32, f64> for IntegerList32 {
                     x as f64 / y as f64
                 }
             })
-            .collect()
+            .collect())
     }
 
     fn div_scala(&self, elem: f64) -> Vec<f64> {
         self.values().iter().map(|x| *x as f64 / elem).collect()
     }
 
-    fn max(&self) -> i32 {
-        self._check_all_na();
+    fn max(&self) -> PyResult<i32> {
+        self._check_all_na()?;
         let hset = self.na_indexes();
-        *self
+        Ok(*self
             .values()
             .iter()
             .enumerate()
             .filter(|(i, _)| !hset.contains(i))
             .map(|(_, x)| x)
             .max()
-            .unwrap()
+            .unwrap())
     }
 
-    fn min(&self) -> i32 {
-        self._check_all_na();
+    fn min(&self) -> PyResult<i32> {
+        self._check_all_na()?;
         let hset = self.na_indexes();
-        *self
+        Ok(*self
             .values()
             .iter()
             .enumerate()
             .filter(|(i, _)| !hset.contains(i))
             .map(|(_, x)| x)
             .min()
-            .unwrap()
+            .unwrap())
     }
 
     fn pow_scala(&self, elem: u32) -> Self {

--- a/ulist/src/integers/int64.rs
+++ b/ulist/src/integers/int64.rs
@@ -37,7 +37,7 @@ impl IntegerList64 {
         List::_new(vec, hset)
     }
 
-    pub fn add(&self, other: &Self) -> Self {
+    pub fn add(&self, other: &Self) -> PyResult<Self> {
         NumericalList::add(self, other)
     }
 
@@ -53,11 +53,11 @@ impl IntegerList64 {
         List::append(self, elem)
     }
 
-    pub fn argmax(&self) -> usize {
+    pub fn argmax(&self) -> PyResult<usize> {
         NumericalList::argmax(self)
     }
 
-    pub fn argmin(&self) -> usize {
+    pub fn argmin(&self) -> PyResult<usize> {
         NumericalList::argmin(self)
     }
 
@@ -98,14 +98,14 @@ impl IntegerList64 {
         List::cycle(&vec, size)
     }
 
-    pub fn div(&self, other: &Self) -> FloatList64 {
+    pub fn div(&self, other: &Self) -> PyResult<FloatList64> {
         let hset: HashSet<usize> = self
             .na_indexes()
             .iter()
             .chain(other.na_indexes().iter())
             .map(|x| x.clone())
             .collect();
-        FloatList64::new(NumericalList::div(self, other), hset)
+        Ok(FloatList64::new(NumericalList::div(self, other)?, hset))
     }
 
     pub fn div_scala(&self, elem: f64) -> FloatList64 {
@@ -117,7 +117,7 @@ impl IntegerList64 {
         List::equal_scala(self, elem)
     }
 
-    pub fn filter(&self, condition: &BooleanList) -> Self {
+    pub fn filter(&self, condition: &BooleanList) -> PyResult<Self> {
         List::filter(self, condition)
     }
 
@@ -125,7 +125,7 @@ impl IntegerList64 {
         List::get(self, index)
     }
 
-    pub fn get_by_indexes(&self, indexes: &IndexList) -> Self {
+    pub fn get_by_indexes(&self, indexes: &IndexList) -> PyResult<Self> {
         List::get_by_indexes(self, indexes)
     }
 
@@ -145,15 +145,15 @@ impl IntegerList64 {
         NumericalList::less_than_scala(self, elem)
     }
 
-    pub fn max(&self) -> i64 {
+    pub fn max(&self) -> PyResult<i64> {
         NumericalList::max(self)
     }
 
-    pub fn min(&self) -> i64 {
+    pub fn min(&self) -> PyResult<i64> {
         NumericalList::min(self)
     }
 
-    pub fn mul(&self, other: &Self) -> Self {
+    pub fn mul(&self, other: &Self) -> PyResult<Self> {
         NumericalList::mul(self, other)
     }
 
@@ -182,7 +182,7 @@ impl IntegerList64 {
         List::replace(self, old, new)
     }
 
-    pub fn set(&self, index: usize, elem: Option<i64>) {
+    pub fn set(&self, index: usize, elem: Option<i64>) -> PyResult<()> {
         List::set(self, index, elem)
     }
 
@@ -194,7 +194,7 @@ impl IntegerList64 {
         NonFloatList::sort(self, ascending)
     }
 
-    pub fn sub(&self, other: &Self) -> Self {
+    pub fn sub(&self, other: &Self) -> PyResult<Self> {
         NumericalList::sub(self, other)
     }
 
@@ -251,35 +251,38 @@ impl List<i64> for IntegerList64 {
 impl NonFloatList<i64> for IntegerList64 {}
 
 impl NumericalList<i64, u32, f64> for IntegerList64 {
-    fn argmax(&self) -> usize {
-        self._check_all_na();
+    fn argmax(&self) -> PyResult<usize> {
+        self._check_all_na()?;
         let hset = self.na_indexes();
-        self.values()
+        Ok(self
+            .values()
             .iter()
             .enumerate()
             .filter(|(i, _)| !hset.contains(i))
             .max_by_key(|x| x.1)
             .unwrap()
-            .0
+            .0)
     }
 
-    fn argmin(&self) -> usize {
-        self._check_all_na();
+    fn argmin(&self) -> PyResult<usize> {
+        self._check_all_na()?;
         let hset = self.na_indexes();
-        self.values()
+        Ok(self
+            .values()
             .iter()
             .enumerate()
             .filter(|(i, _)| !hset.contains(i))
             .min_by_key(|x| x.1)
             .unwrap()
-            .0
+            .0)
     }
 
-    fn div(&self, other: &Self) -> Vec<f64> {
-        self._check_len_eq(other);
+    fn div(&self, other: &Self) -> PyResult<Vec<f64>> {
+        self._check_len_eq(other)?;
         let hset1 = self.na_indexes();
         let hset2 = other.na_indexes();
-        self.values()
+        Ok(self
+            .values()
             .iter()
             .enumerate()
             .zip(other.values().iter())
@@ -290,37 +293,37 @@ impl NumericalList<i64, u32, f64> for IntegerList64 {
                     x as f64 / y as f64
                 }
             })
-            .collect()
+            .collect())
     }
 
     fn div_scala(&self, elem: f64) -> Vec<f64> {
         self.values().iter().map(|x| *x as f64 / elem).collect()
     }
 
-    fn max(&self) -> i64 {
-        self._check_all_na();
+    fn max(&self) -> PyResult<i64> {
+        self._check_all_na()?;
         let hset = self.na_indexes();
-        *self
+        Ok(*self
             .values()
             .iter()
             .enumerate()
             .filter(|(i, _)| !hset.contains(i))
             .map(|(_, x)| x)
             .max()
-            .unwrap()
+            .unwrap())
     }
 
-    fn min(&self) -> i64 {
-        self._check_all_na();
+    fn min(&self) -> PyResult<i64> {
+        self._check_all_na()?;
         let hset = self.na_indexes();
-        *self
+        Ok(*self
             .values()
             .iter()
             .enumerate()
             .filter(|(i, _)| !hset.contains(i))
             .map(|(_, x)| x)
             .min()
-            .unwrap()
+            .unwrap())
     }
 
     fn pow_scala(&self, elem: u32) -> Self {

--- a/ulist/src/string.rs
+++ b/ulist/src/string.rs
@@ -96,7 +96,7 @@ impl StringList {
         List::equal_scala(self, elem)
     }
 
-    pub fn filter(&self, condition: &BooleanList) -> Self {
+    pub fn filter(&self, condition: &BooleanList) -> PyResult<Self> {
         List::filter(self, condition)
     }
 
@@ -104,7 +104,7 @@ impl StringList {
         List::get(self, index)
     }
 
-    pub fn get_by_indexes(&self, indexes: &IndexList) -> Self {
+    pub fn get_by_indexes(&self, indexes: &IndexList) -> PyResult<Self> {
         List::get_by_indexes(self, indexes)
     }
 
@@ -125,7 +125,7 @@ impl StringList {
         List::replace(self, old, new)
     }
 
-    pub fn set(&self, index: usize, elem: Option<String>) {
+    pub fn set(&self, index: usize, elem: Option<String>) -> PyResult<()> {
         List::set(self, index, elem)
     }
 


### PR DESCRIPTION
Using `pyerr` instead of `panic`.