### PR TITLE
uncheck bounds

### DIFF
--- a/ulist/src/base.rs
+++ b/ulist/src/base.rs
@@ -255,10 +255,8 @@ where
     fn replace_na(&self, new: T) {
         let mut vec = self.values_mut();
         for i in self.na_indexes().iter() {
-            // TODO: Use get_unchecked_mut instead.
-            // let ptr = unsafe { vec.get_unchecked_mut(*i) };
-            // *ptr = new.clone();
-            vec[*i] = new.clone();
+            let ptr = unsafe { vec.get_unchecked_mut(*i) };
+            *ptr = new.clone();
         }
         self.na_indexes_mut().clear();
     }

--- a/ulist/src/base.rs
+++ b/ulist/src/base.rs
@@ -233,14 +233,9 @@ where
         let n = self.size();
         let mut vec = self.values_mut();
         for i in 0..n {
-            // TODO: Use get_unchecked_mut instead.
-            // let ptr = unsafe { vec.get_unchecked_mut(i) };
-            // if *ptr == old {
-            //     *ptr = self.na_value();
-            //     self.na_indexes_mut().insert(i);
-            // }
-            if vec[i] == old {
-                vec[i] = self.na_value();
+            let ptr = unsafe{ vec.get_unchecked_mut(i)};
+            if *ptr == old {
+                *ptr = self.na_value();
                 self.na_indexes_mut().insert(i);
             }
         }

--- a/ulist/src/base.rs
+++ b/ulist/src/base.rs
@@ -148,9 +148,6 @@ where
         let mut i = 0;
         for ((j, x), cond) in self.values().iter().enumerate().zip(cond.iter()) {
             if *cond {
-                // TODO: Use get_unchecked_mut instead
-                // let ptr = unsafe { vec.get_unchecked_mut(i) };
-                // *ptr = x.clone();
                 vec.push(x.clone());
                 if self.na_indexes().contains(&j) {
                     hset.insert(i);

--- a/ulist/src/base.rs
+++ b/ulist/src/base.rs
@@ -179,11 +179,11 @@ where
         if indexes.back() >= self.size() {
             return Err(PyIndexError::new_err("Index out of range!"));
         }
-        // TODO: use get_unchecked instead.
         let mut vec: Vec<T> = Vec::new();
         let mut hset: HashSet<usize> = HashSet::new();
         for (i, j) in indexes.values().iter().enumerate() {
-            vec.push(self.values()[*j].clone());
+            let elem = unsafe { self.values().get_unchecked(*j).clone() };
+            vec.push(elem);
             if self.na_indexes().contains(j) {
                 hset.insert(i);
             }

--- a/ulist/src/base.rs
+++ b/ulist/src/base.rs
@@ -266,19 +266,12 @@ where
             return Err(PyIndexError::new_err("Index out of range!"));
         }
         let mut vec = self.values_mut();
-        // TODO: Use get_unchecked_mut instead.
-        // let ptr = unsafe { vec.get_unchecked_mut(index) };
-        // if let Some(i) = elem {
-        //     *ptr = i;
-        // } else {
-        //     *ptr = self.na_value();
-        //     self.na_indexes_mut().insert(index);
-        // }
+        let ptr = unsafe{vec.get_unchecked_mut(index)};
         if let Some(i) = elem {
-            vec[index] = i;
+            *ptr = i;
             self.na_indexes_mut().remove(&index);
         } else {
-            vec[index] = self.na_value();
+            *ptr = self.na_value();
             self.na_indexes_mut().insert(index);
         }
         Ok(())

--- a/ulist/src/base.rs
+++ b/ulist/src/base.rs
@@ -245,13 +245,9 @@ where
         let n = self.size();
         let mut vec = self.values_mut();
         for i in 0..n {
-            // TODO: Use get_unchecked_mut instead.
-            // let ptr = unsafe { vec.get_unchecked_mut(i) };
-            // if *ptr == old {
-            //     *ptr = new.clone();
-            // }
-            if vec[i] == old {
-                vec[i] = new.clone();
+            let ptr = unsafe { vec.get_unchecked_mut(i) };
+            if *ptr == old {
+                *ptr = new.clone();
             }
         }
     }

--- a/ulist/src/base.rs
+++ b/ulist/src/base.rs
@@ -9,10 +9,8 @@ use std::collections::HashSet;
 
 pub fn _fill_na<T: Clone>(vec: &mut [T], na_indexes: Ref<HashSet<usize>>, na_value: T) {
     for i in na_indexes.iter() {
-        // TODO: Use get_unchecked_mut instead.
-        // let ptr = unsafe { vec.get_unchecked_mut(*i) };
-        // *ptr = na_value.clone();
-        vec[*i] = na_value.clone();
+        let ptr = unsafe { vec.get_unchecked_mut(*i) };
+        *ptr = na_value.clone();
     }
 }
 

--- a/ulist/src/base.rs
+++ b/ulist/src/base.rs
@@ -174,12 +174,10 @@ where
     }
 
     fn get_by_indexes(&self, indexes: &IndexList) -> PyResult<Self> {
-        // TODO: Put this kind of check
-        // where there is unsafe block.
         if indexes.back() >= self.size() {
             return Err(PyIndexError::new_err("Index out of range!"));
         }
-        let mut vec: Vec<T> = Vec::new();
+        let mut vec: Vec<T> = Vec::with_capacity(indexes.size());
         let mut hset: HashSet<usize> = HashSet::new();
         for (i, j) in indexes.values().iter().enumerate() {
             let elem = unsafe { self.values().get_unchecked(*j).clone() };
@@ -188,6 +186,7 @@ where
                 hset.insert(i);
             }
         }
+        hset.shrink_to_fit();
         Ok(List::_new(vec, hset))
     }
 

--- a/ulist/src/boolean.rs
+++ b/ulist/src/boolean.rs
@@ -181,7 +181,7 @@ impl BooleanList {
         self._check_len_eq(other)?;
         let hset1 = self.na_indexes();
         let hset2 = other.na_indexes();
-        let mut hset: HashSet<usize> = HashSet::new();
+        let mut hset: HashSet<usize> = HashSet::with_capacity(max(hset1.len(), hset2.len()));
         let vec = self
             .values()
             .iter()
@@ -207,6 +207,7 @@ impl BooleanList {
                 }
             })
             .collect();
+        hset.shrink_to_fit();
         Ok(BooleanList::new(vec, hset))
     }
 

--- a/ulist/src/boolean.rs
+++ b/ulist/src/boolean.rs
@@ -19,6 +19,7 @@ use std::cell::RefMut;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::ops::Fn;
+use std::cmp::max;
 
 /// List with boolean type elements.
 #[pyclass]
@@ -57,7 +58,7 @@ impl BooleanList {
         self._check_len_eq(other)?;
         let hset1 = self.na_indexes();
         let hset2 = other.na_indexes();
-        let mut hset: HashSet<usize> = HashSet::new();
+        let mut hset: HashSet<usize> = HashSet::with_capacity(max(hset1.len(), hset2.len()));
         let vec = self
             .values()
             .iter()
@@ -83,6 +84,7 @@ impl BooleanList {
                 }
             })
             .collect();
+        hset.shrink_to_fit();
         Ok(BooleanList::new(vec, hset))
     }
 

--- a/ulist/src/control_flow.rs
+++ b/ulist/src/control_flow.rs
@@ -34,12 +34,13 @@ where
     }
 
     let mut vec = vec![default; cond[0].size()];
-    // for j in 0..cond[0].size() {
-    for (j, item) in vec.iter_mut().enumerate().take(cond[0].size()) {
+    for j in 0..vec.len() {
         for i in 0..cond.len() {
-            // TODO: Improve the benchmark.
-            if cond[i].get(j).unwrap().unwrap() {
-                *item = choices[i].clone();
+            let ptr = unsafe { cond.get_unchecked(i) };
+            let choice = unsafe { choices.get_unchecked(i) };
+            // TODO: implement iter() for BooleanList
+            if ptr.get(j).unwrap().unwrap() {
+                vec[j] = choice.clone();
                 break;
             }
         }

--- a/ulist/src/floatings/float32.rs
+++ b/ulist/src/floatings/float32.rs
@@ -257,7 +257,7 @@ impl FloatList32 {
             vec.push(self.na_value());
         }
         // Construct List.
-        let mut hset = HashSet::new();
+        let mut hset = HashSet::with_capacity(1);
         if self.count_na() > 0 {
             hset.insert(vec.len() - 1);
         }

--- a/ulist/src/floatings/float64.rs
+++ b/ulist/src/floatings/float64.rs
@@ -257,7 +257,7 @@ impl FloatList64 {
             vec.push(self.na_value());
         }
         // Construct List.
-        let mut hset = HashSet::new();
+        let mut hset = HashSet::with_capacity(1);
         if self.count_na() > 0 {
             hset.insert(vec.len() - 1);
         }

--- a/ulist/src/index.rs
+++ b/ulist/src/index.rs
@@ -49,4 +49,8 @@ impl IndexList {
     pub fn to_list(&self) -> Vec<usize> {
         self._values.clone()
     }
+
+    pub fn size(&self) -> usize {
+        self._values.len()
+    }
 }

--- a/ulist/src/non_float.rs
+++ b/ulist/src/non_float.rs
@@ -65,7 +65,7 @@ where
             }
         };
         // Construct List.
-        let mut hset = HashSet::new();
+        let mut hset = HashSet::with_capacity(1);
         if self.count_na() > 0 {
             hset.insert(vec_dedup.len() - 1);
         }


### PR DESCRIPTION
What's new?
- Use unsafe methods to visit vector / hashmap elements, so as to improve the benchmark;
- Use with_capacity or shrink_to_fit to reduce memory usage;